### PR TITLE
feat: miseでZenn CLIを依存に追加

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"npm:zenn-cli" = "0.5.3"


### PR DESCRIPTION
mise で Zenn CLI (zenn-cli) を依存に追加します。

- `mise.toml` に `npm:zenn-cli@0.5.3` を追加
- これにより `mise exec -- zenn ...` で Zenn CLI が利用可能に